### PR TITLE
Adds support for separation of the api and data network

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -175,9 +175,14 @@ Vagrant.configure("2") do |config|
   # accessing "localhost:8080" will access port 80 on the guest machine.
   # config.vm.network "forwarded_port", guest: 80, host: 8080
 
-  # Create a private network, which allows host-only access to the machine
+  # Create a two private networks, which each allow host-only access to the machine
   # using a specific IP.
-  config.vm.network "private_network", ip: "#{options[:cassandra_addr]}"
+  if options[:cassandra_addr]
+    config.vm.network "private_network", ip: "#{options[:cassandra_addr]}"
+    split_addr = options[:cassandra_addr].split('.')
+    api_addr = (split_addr[0..1] + [(split_addr[2].to_i + 10).to_s] + [split_addr[3]]).join('.')
+    config.vm.network "private_network", ip: api_addr
+  end
 
   # Create a public network, which generally matched to bridged network.
   # Bridged networks make the machine appear as another physical device on
@@ -234,7 +239,10 @@ Vagrant.configure("2") do |config|
         proxy_password: proxy_password
       },
       host_inventory: cassandra_addr_array,
-      cassandra_iface: "eth1",
+      cassandra_seed_nodes: cassandra_addr_array,
+      inventory_type: "static",
+      data_iface: "eth1",
+      api_iface: "eth2",
       cassandra_jvm_heaps_size: "2G",
       cassandra_swap_mode: "on",
       cassandra_trickle_fsync: false

--- a/site.yml
+++ b/site.yml
@@ -158,13 +158,15 @@
       setup:
   roles:
     - role: get-iface-addr
-      iface_name: "{{cassandra_iface}}"
+      iface_name: "{{data_iface}}"
+      as_fact: "data_addr"
+    - role: get-iface-addr
+      iface_name: "{{api_iface}}"
+      as_fact: "api_addr"
     - role: setup-web-proxy
     - role: add-local-repository
-      yum_repository: "{{yum_repo_addr}}"
-      when: yum_repo_addr is defined
+      yum_repository: "{{yum_repo_url}}"
+      when: yum_repo_url is defined
     - role: install-packages
       package_list: "{{combined_package_list}}"
     - role: dn-cassandra
-      cassandra_addr: "{{iface_addr}}"
-

--- a/tasks/configure-cassandra-nodes.yml
+++ b/tasks/configure-cassandra-nodes.yml
@@ -5,16 +5,21 @@
 # was passed into the playbook)
 - block:
   - name: When creating a cluster, set RPC/listen addresses and auto_bootstrap value
-    replace:
+    lineinfile:
       dest: "{{cassandra_dir}}/conf/cassandra.yaml"
-      regexp: "^(.*)(#)?(.*){{item.key}}:.*$"
-      replace: '\g<1> \g<3>{{item.key}}: {{item.value}}'
-    with_dict:
-      cluster_name: "{{cassandra_cluster_name}}"
-      listen_address: "{{iface_addr}}"
-      rpc_address: "{{iface_addr}}"
-      auto_bootstrap: false
+      regexp: "{{item.pattern}}"
+      line: "{{item.key}}: {{item.value}}"
+      state: present
+    with_items:
+      - { pattern: "^listen_address:", key: "listen_address", value: "{{data_addr}}" }
+      - { pattern: "^# broadcast_address:", key: "broadcast_address", value: "{{data_addr}}" }
+      - { pattern: "^rpc_address:", key: "rpc_address", value: "{{api_addr}}" }
+      - { pattern: "^auto_bootstrap:", key: "auto_bootstrap", value: "false" }
+  - name: Set cluster name if a cluster name value was passed in
+    lineinfile:
+      dest: "{{cassandra_dir}}/conf/cassandra.yaml"
+      regexp: "^cluster_name:"
+      line: "cluster_name: {{tenant}}{{project}}{{cluster_name_suffix | default('')}}"
+      state: present
   become: true
   become_user: "{{cassandra_user}}"
-  when: not (cassandra_cluster_name is undefined or cassandra_cluster_name is none or cassandra_cluster_name | trim == '')
-  

--- a/tasks/install-apache-cassandra.yml
+++ b/tasks/install-apache-cassandra.yml
@@ -3,7 +3,8 @@
 # set a fact containing the appropriate (private) IP addresses of the cassandra_seed_nodes
 # (if a list of cassandra_seed_nodes was passed in)
 - set_fact:
-    cass_seed_nodes: "{{cassandra_seed_nodes | map('extract', hostvars, [('ansible_' + cassandra_iface), 'ipv4', 'address']) | list}}"
+    cassandra_data_ips: "{{cassandra_seed_nodes | map('extract', hostvars, [('ansible_' + data_iface), 'ipv4', 'address']) | list}}"
+    cassandra_api_ips: "{{cassandra_seed_nodes | map('extract', hostvars, [('ansible_' + api_iface), 'ipv4', 'address']) | list}}"
 # download the Cassandra distribution from the input URL
 - name: Download cassandra distribution to /tmp
   become: true

--- a/templates/cassandra.yaml.j2
+++ b/templates/cassandra.yaml.j2
@@ -340,7 +340,7 @@ seed_provider:
       parameters:
           # seeds is actually a comma-delimited list of addresses.
           # Ex: "<ip1>,<ip2>,<ip3>"
-          - seeds: "{{ cass_seed_nodes | join(',') }}"
+          - seeds: "{{ cassandra_data_ips | join(',') }}"
 
 # For workloads with more data than can fit in memory, Cassandra's
 # bottleneck will be reads that need to fetch data from

--- a/vars/cassandra.yml
+++ b/vars/cassandra.yml
@@ -43,5 +43,15 @@ cassandra_jmxremote_ciphers: "SSL_RSA_WITH_RC4_128_MD5, SSL_RSA_WITH_RC4_128_SHA
 cassandra_keystore_dir: "{{ cassandra_dir }}/conf/.keystore"
 cassandra_truststore_dir: "{{ cassandra_dir }}/conf/.truststore"
 
+# the names of the interfaces to use for the Cassandra servers; the "data"
+# interface is the private interface that is used to communicate with other
+# members of the cluster (and Zookeeper), while the "api" interface is the
+# interface that the database listens on for connections from clients
+api_iface: "eth0"
+data_iface: "eth0"
+
 # path used to access private keys (defaults to the current working directory)
 private_key_path: "."
+
+# a suffix used to create a unique cluster name (if defined)
+# cluster_name_suffix: ""


### PR DESCRIPTION
The changes in this pull request modify the existing playbook; adding support for separation between a private network (the data network used by the cluster to communicate) and a public network (the API network that the cluster listens on for client connections).  In situations where this separation is not important, the two parameters used to define these networks can simply be set to the same network interface, eg. `eth0` (in fact, this is how the defaults defined in the `vars/cassandra.yml` file are setup).

This pull request also modifies the cluster deployment process to configure some parameters that were not configured in previous versions of the playbook (like the cluster name).

Finally, this pull request also contains a separate (unrelated) change to how a local mirror is passed into the playbook (in situations where access to the standard yum repositories is not possible).  The mirror is now defined as a URL instead of a hostname/IP address (to reflect recent changes in the underlying `common-roles/add-local-repository` role).  This should make it easier to support whatever directory structure was used when defining the local repository.