### PR TITLE
Adds support for skipping nodes during a Cassandra deployment

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -4,6 +4,8 @@
 - name: Create cassandra and cassandra_seed host groups
   hosts: "{{host_inventory}}"
   gather_facts: no
+  vars_files:
+    - vars/cassandra.yml
   tasks:
     - include_role:
         name: build-app-host-groups
@@ -19,17 +21,24 @@
           - { name: cassandra, node_list: "{{host_inventory}}" }
           - { name: cassandra_seed, node_list: "{{cassandra_seed_nodes | default([])}}" }
       when: cloud == "vagrant"
+    - set_fact:
+        cassandra_nodes: "{{cassandra_nodes | difference(groups['cassandra_skip'] | default([]))}}"
+      when: (groups['cassandra_skip'] | default([])) != []
+    - set_fact:
+        seed_nodes_only: true
+        cassandra_nodes: "{{cassandra_seed_nodes}}"
+      when: (groups['cassandra'] | default([])) == []
 
 # Build a cassandra group from the cassandra_seed host group if no non-seed nodes were found
 - name: Build cassandra host group if no non-seed nodes were found
   hosts: cassandra_seed
   gather_facts: no
   tasks:
-    - add_host:
-        name: "{{item}}"
-        groups: cassandra
-      with_items: "{{groups['cassandra_seed']}}"
-      when: cassandra_nodes == []
+      - add_host:
+          name: "{{item}}"
+          groups: cassandra
+        with_items: "{{groups['cassandra_seed']}}"
+        when: seed_nodes_only is defined and seed_nodes_only
 
 # Gather facts for the cassandra seed nodes if a set of non-seed nodes were found
 - name: Gather facts for cassandra seed nodes if there are non-seed nodes
@@ -37,7 +46,7 @@
   gather_facts: no
   tasks:
     - setup:
-      when: not (cassandra_nodes == [])
+      when: seed_nodes_only is undefined or not (seed_nodes_only)
 
 # Then, deploy Cassandra to the nodes in the cassandra host group that was passed in (if there
 # is more than one node passed in, those nodes will be configured as a single Cassandra cluster)

--- a/tasks/configure-cassandra-nodes.yml
+++ b/tasks/configure-cassandra-nodes.yml
@@ -14,7 +14,7 @@
       - { pattern: "^listen_address:", key: "listen_address", value: "{{data_addr}}" }
       - { pattern: "^# broadcast_address:", key: "broadcast_address", value: "{{data_addr}}" }
       - { pattern: "^rpc_address:", key: "rpc_address", value: "{{api_addr}}" }
-      - { pattern: "^auto_bootstrap:", key: "auto_bootstrap", value: "false" }
+      - { pattern: "^auto_bootstrap:", key: "auto_bootstrap", value: "{{(auto_bootstrap | default(false)) | lower}}" }
   - name: Set cluster name based on tenant and project if those values are defined
     lineinfile:
       dest: "{{cassandra_dir}}/conf/cassandra.yaml"

--- a/tasks/start-cassandra-services.yml
+++ b/tasks/start-cassandra-services.yml
@@ -5,3 +5,4 @@
   service:
     name: cassandra
     state: restarted
+  when: start_cassandra is defined and start_cassandra

--- a/vars/cassandra.yml
+++ b/vars/cassandra.yml
@@ -53,5 +53,24 @@ data_iface: "eth0"
 # path used to access private keys (defaults to the current working directory)
 private_key_path: "."
 
+# flag that can be set to start the cassandra service when the playbook
+# finishes running (defaulting this to false to starting a potentially
+# misconfigured node or nodes when adding new nodes to an existing cluster)
+start_cassandra: false
+
+# can be used to reset the 'auto_bootstrap' flag when adding new nodes to
+# an existing cluster by setting this flag to true
+auto_bootstrap: false
+
+# a list of "regular" cassandra nodes that should be skipped in the provisioning
+# process (can be used to filter out the existing nodes from the list of nodes
+# returned by the dynamic inventory scripts)
+skip_nodes_list: []
+
+# a regular expression that can be used to identify which of the IP addresses
+# returned by the openstack inventory script is the private network used for
+# provisioning
+osp_private_net_regex: '10\.[0-9]+\.0\.[0-9]+'
+
 # a suffix used to create a unique cluster name (if defined)
 # cluster_name_suffix: ""


### PR DESCRIPTION
The changes in this pull request add support for skipping nodes that match the tags passed into the `ansible-playbook` run (when using the dynamic inventory scripts to discover the nodes that should be targeted for a new Cassandra installation).

In addition to adding the ability to skip nodes (using a list passed into the `ansible-playbook` command using the `skip_nodes_list` parameter, this PR also adds:

* A `start_cassandra` flag has been added that can be used to instruct the playbook to start the `cassandra` service when the playbook completes; this flag defaults to `false`
* An `auto_bootstrap` flag has been added that can be used to set the `auto_bootstrap` parameter in the `cassandra.yaml` configuration file to `true`; again this flag defaults to `false`

As an example of how this can be used (with the OpenStack dynamic inventory script), the following sequence of commands was used to create a new "cluster" containing two seed nodes, then add a single non-seed node to that cluster, then sometime later (after data has been loaded into the three node cluster built by those two commands), deploy Cassandra to three more non-seed nodes and configure them to auto boostrap into that cluster (but not actually start the Cassandra service on those nodes so that they can be added to the cluster one at a time):

```bash
$ NO_PROXY=auiag.corp ansible-playbook -i common-utils/inventory/osp/openstack -e "{ host_inventory: 'meta-Application_cassandra:&meta-Cloud_osp:&meta-Tenant_iagcl:&meta-Project_svx:&meta-Domain_production', application: cassandra, cloud: osp, tenant: iagcl, project: svx, domain: production, ansible_user: cloud-user, inventory_type: dynamic, private_key_path: '/Volumes/Extern-USB/IAG/OpenStack-Keys', data_iface: eth0, api_iface: eth1, cassandra_url: 'https://swlibrary.iag.com.au/nexus/service/local/repositories/thirdparty/content/org/apache/apache-cassandra/3.0.11/apache-cassandra-3.0.11.tar.gz', cassandra_data_dir: '/data', skip_nodes_list: ['10.10.0.21', '10.10.0.35', '10.10.0.37', '10.10.0.41'], start_cassandra: true }" site.yml
...
$ NO_PROXY=auiag.corp ansible-playbook -i common-utils/inventory/osp/openstacddk -e "{ host_inventory: 'meta-Application_cassandra:&meta-Cloud_osp:&meta-Tenant_iagcl:&meta-Project_svx:&meta-Domain_production', application: cassandra, cloud: osp, tenant: iagcl, project: svx, domain: production, ansible_user: cloud-user, inventory_type: dynamic, private_key_path: '/Volumes/Extern-USB/IAG/OpenStack-Keys', data_iface: eth0, api_iface: eth1, cassandra_url: 'https://swlibrary.iag.com.au/nexus/service/local/repositories/thirdparty/content/org/apache/apache-cassandra/3.0.11/apache-cassandra-3.0.11.tar.gz', cassandra_data_dir: '/data', skip_nodes_list: ['10.10.0.35', '10.10.0.37', '10.10.0.41'], start_cassandra: true }" site.yml
...
$ NO_PROXY=auiag.corp ansible-playbook -i common-utils/inventory/osp/openstack -e "{ host_inventory: 'meta-Application_cassandra:&meta-Cloud_osp:&meta-Tenant_iagcl:&meta-Project_svx:&meta-Domain_production', application: cassandra, cloud: osp, tenant: iagcl, project: svx, domain: production, ansible_user: cloud-user, inventory_type: dynamic, private_key_path: '/Volumes/Extern-USB/IAG/OpenStack-Keys', data_iface: eth0, api_iface: eth1, cassandra_url: 'https://swlibrary.iag.com.au/nexus/service/local/repositories/thirdparty/content/org/apache/apache-cassandra/3.0.11/apache-cassandra-3.0.11.tar.gz', cassandra_data_dir: '/data', skip_nodes_list: ['10.10.0.21'], auto_bootstrap: true }" site.yml
```

In this example, the six nodes in question (with IP addresses `10.10.0.19`, `10.10.0.20`, `10.10.0.21`, `10.10.0.35`, `10.10.0.27`, and `10.10.0.41` of were all tagged as `cassandra` nodes, and the nodes with IP addresses of `10.10.0.19` and `10.10.0.20` were also tagged with a `seed` role.  When the last command finished and we had started the cassandra service on the last three nodes individually, all six nodes were up and running and the data was split evenly between them.