### PR TITLE
update to latest stable cassandra; track latest common flows

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # (c) 2017 DataNexus Inc.  All Rights Reserved
 
 # Default values that are expected to be overridden
-cassandra_version: "3.10"
+cassandra_version: "3.11.0"
 cassandra_url: "http://www-us.apache.org/dist/cassandra/{{ cassandra_version }}/apache-cassandra-{{ cassandra_version }}-bin.tar.gz"
 
 cassandra_cluster_name: "Test Cluster"


### PR DESCRIPTION
* 3.10 was removed from the apache site, so update to 3.11
* update to latest common flows