### PR TITLE
Fixes issue with the cassandra service not restarting

### DIFF
--- a/tasks/create-cassandra-services.yml
+++ b/tasks/create-cassandra-services.yml
@@ -1,13 +1,5 @@
 # (c) 2017 DataNexus Inc.  All Rights Reserved
 ---
-- name: Create a cassandra PID dir
-  become: yes
-  file:
-    path: /var/run/cassandra
-    state: directory
-    mode: 0755
-    owner: "{{cassandra_user}}"
-    group: "{{cassandra_group}}"
 - name: Create cassandra service files
   become: true
   template:

--- a/templates/cassandra.service.j2
+++ b/templates/cassandra.service.j2
@@ -8,8 +8,11 @@ After=network.target remote-fs.target
 Type=simple
 PIDFile=/var/run/cassandra/cassandra.pid
 WorkingDirectory={{cassandra_dir}}
-User=cassandra
-Group=cassandra
+User={{cassandra_user}}
+Group={{cassandra_group}}
+PermissionsStartOnly=true
+ExecStartPre=-/usr/bin/mkdir /var/run/cassandra
+ExecStartPre=/usr/bin/chown -R {{cassandra_user}}:{{cassandra_group}} /var/run/cassandra/
 ExecStart={{cassandra_dir}}/bin/cassandra -p /var/run/cassandra/cassandra.pid
 
 # When Cassandra stops, it may exit with status 2 - see https://issues.apache.org/jira/browse/CASSANDRA-13030


### PR DESCRIPTION
The changes in this pull request fix a bug that was causing the `cassandra` service to not restart after a node was rebooted using a `shutdown -r` command (or any other command that triggers a node shutdown and restart).  In that case, the `/var/run/cassandra` directory that is used to store the PID file for the `cassandra` service was not recreated after the reboot (the `/var/run` filesystem is an in-memory filesystem so changes made to that filesystem don't persist across reboots), so the `cassandra` service failed to restart (since the directory it uses to store it's PID file didn't exist any longer).  With the three extra lines this pull request adds to the `templates/cassandra.service.j2` file this bug is resolved.

As we were making these changes, we also noticed that the `cassandra_user` and `cassandra_group` variables that are used elsewhere in the playbook to indicate the cassandra username and the group that the cassandra username is been placed in were not used in this template, so we've fixed that potential issue as well.